### PR TITLE
Add read timeout + character delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # libabbaurora changelog
 
+## v0.2.2 - 2023-11-23
+* add serial read timeout + character read delay
 ## v0.2.1 - 2022-01-02
 * improve debug logging
 

--- a/include/ABBAurora.h
+++ b/include/ABBAurora.h
@@ -1,5 +1,7 @@
 #ifndef ABBAurora_h
 #define ABBAurora_h
+
+#include <stdint.h>
 #include "ABBAuroraEnums.h"
 #include "ABBAuroraSerial.h"
 
@@ -79,9 +81,11 @@ public:
 
       @param device Serial device, i.e. /dev/ttyUSB0
       @param baudrate Optional baud rate
+      @param max_read_iterations Max serial read iterations
+      @param character_delay Max delay between character reads in microseconds
       */
-  bool Setup(const std::string &device, const speed_t baudrate = B19200);
-  /** @brief Set serial device address
+  bool Setup(const std::string &device, const speed_t baudrate, const int &max_read_iterations, const int &character_delay);
+  /** @brief Set zerial device address
 
       Sets a new RS485 serial device address     
 

--- a/include/ABBAuroraSerial.h
+++ b/include/ABBAuroraSerial.h
@@ -30,14 +30,17 @@ public:
 
     @param device The serial device, i.e. /dev/ttyUSB0
     @param baudrate The serial baud rate
+    @param max_read_iterations Max read iterations to wait for data arrival
+    @param character_delay Inter character read delay
     */
-  bool Begin(const std::string &device, const speed_t &baudrate);
+  bool Begin(const std::string &device, const speed_t &baudrate, const int &max_read_iterations, const int &character_delay);
 /** @brief Read bytes
 
     Read bytes available in the input buffer
 
     @param buffer Buffer to store the bytes
-    @param length Number of bytes to read 
+    @param length Number of bytes to read
+
     */
   int ReadBytes(uint8_t *buffer, const int &length);
 /** @brief Write bytes
@@ -94,6 +97,8 @@ public:
 
 private:
   int SerialPort; ///< Serial port number
+  int MaxReadIterations = 1000; ///< Max number of read iterations
+  int CharacterDelay = 52; ///< Delay between reading characters
   std::string ErrorMessage; ///< Error message string
   unsigned char Log; ///< Log level
 };

--- a/src/ABBAurora.cpp
+++ b/src/ABBAurora.cpp
@@ -28,11 +28,11 @@ void ABBAurora::SetLogLevel(const unsigned char &log_level)
   Log = log_level;
 }
 
-bool ABBAurora::Setup(const std::string &device, const speed_t baudrate)
+bool ABBAurora::Setup(const std::string &device, const speed_t baudrate, const int &max_read_iterations, const int &character_delay)
 {
   ReceiveData = new uint8_t[ABBAurora::ReceiveBufferSize] ();
   Serial = new ABBAuroraSerial(Log);
-  if (!Serial->Begin(device, baudrate))
+  if (!Serial->Begin(device, baudrate, max_read_iterations, character_delay))
   {
     ErrorMessage = Serial->GetErrorMessage();
     return false;


### PR DESCRIPTION
This PR extracts serial read iterations + character delay as parameters. I had to have my aurora repaired recently due to the common E031 failure. A relay was replaced and I took a further look at the data logging, it's still giving me a lot of read timeouts and CRC errors.
* I changed the wiring to shielded CAT6 with twisted pair for the differential RS485 pair. Also the shielding is grounded on the adapter's return pin. This seems to be a recommendation from the manual.
* After doing this, I hardly saw any improvements in the amount of serial errors (timeouts, CRC). I looked at the original aurora tool written by Curtis and he had some params to change the inter character delay, which I also introduced now here.

I'll try to play a bit with thos values to see if they improve the connection reliability a bit.
